### PR TITLE
Add basic CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,6 @@ jobs:
           check-latest: true
           stable: true
 
-      - name: Install Discord.v system dependencies
-        run: sudo apt-get install --quiet -y libssl-dev
-
       - name: Install Discord.v fork
         run: v install --git https://github.com/kintrix007/discordv.git
 


### PR DESCRIPTION
Compiles on Ubuntu 20.04 and 22.04. I do not think we care about it running on Windows... Especially because of the libssl dependency of Discord.v